### PR TITLE
Code Refactoring

### DIFF
--- a/src/main/scala/models/SupportedType.scala
+++ b/src/main/scala/models/SupportedType.scala
@@ -8,30 +8,14 @@ sealed trait SupportedType {
   val input: InputType
 }
 
-case class FileType(input: File) extends SupportedType {
-  override type InputType = File
-}
+sealed trait TraversableType[A <: TraversableOnce[String]] extends SupportedType { override type InputType = A }
+sealed trait NonTraversableType[A] extends SupportedType { override type InputType = A }
 
-case class IteratorType(input: Iterator[String]) extends SupportedType {
-  override type InputType = Iterator[String]
-}
+final case class IteratorType(input: Iterator[String]) extends TraversableType[Iterator[String]]
+final case class IterableType(input: Iterable[String]) extends TraversableType[Iterable[String]]
+final case class SeqType(input: Seq[String]) extends TraversableType[Seq[String]]
+final case class StreamType(input: Stream[String]) extends TraversableType[Stream[String]]
 
-case class IterableType(input: Iterable[String]) extends SupportedType {
-  override type InputType = Iterable[String]
-}
-
-case class ReaderType(input: Reader) extends SupportedType {
-  override type InputType = Reader
-}
-
-case class SeqType(input: Seq[String]) extends SupportedType {
-  override type InputType = Seq[String]
-}
-
-case class SourceType(input: Source) extends SupportedType {
-  override type InputType = Source
-}
-
-case class StreamType(input: Stream[String]) extends SupportedType {
-  override type InputType = Stream[String]
-}
+final case class FileType(input: File) extends NonTraversableType[File]
+final case class ReaderType(input: Reader) extends NonTraversableType[Reader]
+final case class SourceType(input: Source) extends NonTraversableType[Source]

--- a/src/main/scala/parsing/Parser.scala
+++ b/src/main/scala/parsing/Parser.scala
@@ -3,142 +3,81 @@ package parsing
 import models._
 
 import scala.io.Source
-import scala.util.Try
 
 object Parser extends Encoding {
 
   def parse(parserInput: ParserInput): ParsedCSV = {
-    parsedCsv(extractHeaders(parserInput))
+    parsedCsv(extractHeaders(toTraversable(parserInput)))
   }
 
-  private val parsedCsv: ParserInput => ParsedCSV = parserInput => {
-    parserInput.in match {
-      case IteratorType(input) => ???
-
-      case IterableType(input) => ???
+  private val toTraversable: ParserInput => ParserInput = { parserInput =>
+    val convert: NonTraversableType[_] => TraversableType[_] = {
+      case SourceType(input) =>
+        val allLines: Iterator[String] = input.getLines()
+        input.close()
+        IteratorType(allLines)
 
       case ReaderType(input) =>
-        val source: Source = Source.fromString(input.toString)
-        val sourceLines: Iterator[String] = source.getLines()
-        val parsed: Seq[Either[EncodeType, EncodeType]] = sourceLines.toList.map(parsingLogic)
+        val chars: Array[Char] = Iterator.continually(input.read().toChar).toArray
+        val source: Source = Source.fromChars(chars)
+        val allLines: Iterator[String] = source.getLines()
         source.close()
-        val (
-          droppedLines: List[Either[String, String]],
-          parsedLines: List[Either[String, String]]
-        ) = parsed.partition(_.isLeft)
+        IteratorType(allLines)
 
-        ParsedCSV(
-          headers = parserInput.headers,
-          parsedLines = droppedLines.map(_.merge),
-          droppedLines = parsedLines.map(_.merge)
-        )
+      case FileType(input) =>
+        val source: Source = Source.fromFile(input.toString)
+        val allLines: Iterator[String] = source.getLines()
+        source.close()
+        IteratorType(allLines)
+    }
 
-      case SeqType(input) =>
-        val parsed: Seq[Either[String, String]] = input.map(parsingLogic)
-
-        val (
-          droppedLines: List[Either[String, String]],
-          parsedLines: List[Either[String, String]]
-        ) = parsed.partition(_.isLeft)
-
-        ParsedCSV(
-          headers = parserInput.headers,
-          parsedLines = droppedLines.map(_.merge),
-          droppedLines = parsedLines.map(_.merge)
-        )
-
-      case SourceType(input) =>
-        val parsed: Iterator[Either[EncodeType, EncodeType]] = input.getLines().map(parsingLogic)
-
-        val (
-          droppedLines: Iterator[Either[String, String]],
-          parsedLines: Iterator[Either[String, String]]
-        ) = parsed.partition(_.isLeft)
-
-        ParsedCSV(
-          headers = parserInput.headers,
-          parsedLines = droppedLines.map(_.merge).toList,
-          droppedLines = parsedLines.map(_.merge).toList
-        )
-
-      case StreamType(input) =>
-        val parsed: Stream[Either[String, String]] = input.map(parsingLogic)
-
-        val (
-          droppedLines: List[Either[String, String]],
-          parsedLines: List[Either[String, String]]
-        ) = parsed.toList.partition(_.isLeft)
-
-        ParsedCSV(
-          headers = parserInput.headers,
-          parsedLines = droppedLines.map(_.merge),
-          droppedLines = parsedLines.map(_.merge)
+    parserInput.in match {
+      case _: TraversableType[_] => parserInput
+      case input: NonTraversableType[_] =>
+        ParserInput(
+          in = convert(input),
+          csvDefinition = parserInput.csvDefinition,
+          headers = parserInput.headers
         )
     }
   }
 
   private val extractHeaders: ParserInput => ParserInput = { parserInput =>
-    {
-      if (parserInput.headers.isEmpty) {
-        parserInput.in match {
-          case FileType(input) =>
-            val source: Source = Source.fromFile(input.toString)
-            val sourceLines: Iterator[String] = source.getLines()
-            val headers: List[EncodeType] = sourceLines.take(1).toList
-            val lines: Iterator[String] = sourceLines
-            source.close()
-            ParserInput(
-              in = IteratorType(lines),
-              csvDefinition = parserInput.csvDefinition,
-              headers = headers
-            )
+    def buildParserInput(input: TraversableType[_], headers: List[String]): ParserInput = ParserInput(
+      in = input,
+      csvDefinition = parserInput.csvDefinition,
+      headers = headers
+    )
 
-          case IteratorType(input) => ???
-
-          case IterableType(input) => ???
-
-          case ReaderType(input) =>
-            val source: Source = Source.fromString(input.toString)
-            val sourceLines: Iterator[String] = source.getLines()
-            val headers: Seq[EncodeType] = sourceLines.take(1).toList
-            val lines = sourceLines
-            source.close()
-            ParserInput(
-              in = IteratorType(lines),
-              csvDefinition = parserInput.csvDefinition,
-              headers = headers.toList
-            )
-
-          case SeqType(input) =>
-            val headers: List[String] = input.take(1).toList
-            val lines: Seq[String] = input.drop(1)
-            ParserInput(
-              in = SeqType(lines),
-              csvDefinition = parserInput.csvDefinition,
-              headers = headers
-            )
-
-          case SourceType(input) =>
-            val headers: Iterator[String] = input.getLines().take(1)
-            val lines: Iterator[String] = input.getLines()
-            ParserInput(
-              in = IteratorType(lines),
-              csvDefinition = parserInput.csvDefinition,
-              headers = headers.toList
-            )
-
-          case StreamType(input) =>
-            val headers: List[String] = input.take(1).toList
-            val lines: Stream[String] = input.drop(1)
-            ParserInput(
-              in = StreamType(lines),
-              csvDefinition = parserInput.csvDefinition,
-              headers = headers
-            )
-        }
-      } else {
-        parserInput
+    if (parserInput.headers.nonEmpty) parserInput
+    else {
+      parserInput.in match {
+        case IteratorType(input) => buildParserInput(IteratorType(input.drop(1)), input.take(1).toList)
+        case IterableType(input) => buildParserInput(IterableType(input.drop(1)), input.take(1).toList)
+        case SeqType(input)      => buildParserInput(SeqType(input.drop(1)), input.take(1).toList)
+        case StreamType(input)   => buildParserInput(StreamType(input.drop(1)), input.take(1).toList)
       }
+    }
+  }
+
+  private val parsedCsv: ParserInput => ParsedCSV = parserInput => {
+    def applyParsingLogic(lines: List[String]): ParsedCSV = {
+      val parsed: List[Either[EncodeType, EncodeType]] = lines.map(parsingLogic)
+
+      val (
+        droppedLines: List[Either[String, String]],
+        parsedLines: List[Either[String, String]]
+      ) = parsed.partition(_.isLeft)
+
+      ParsedCSV(
+        headers = parserInput.headers,
+        parsedLines = parsedLines.map(_.merge),
+        droppedLines = droppedLines.map(_.merge)
+      )
+    }
+
+    parserInput.in match {
+      case traversableType: TraversableType[_] => applyParsingLogic(traversableType.input.toList)
     }
   }
 


### PR DESCRIPTION
So the main idea behind the change here was to reduce the boilerplate in Parser.scala; Main changes:

- Separated Supported Types in two types

1. `ParsableType` (Ready to be Parsed) (`IteratorType`, `IterableType`, `SeqType`, `StreamType`)
2. `NonParsableType` (Need tinkering before beeing ready to Parse) (`FileType`, `ReaderType`, `SourceType`)

Created a Draft PR while waiting for #24 implementation